### PR TITLE
Bug Fixes in MDCA and AAD

### DIFF
--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -1,4 +1,4 @@
-from modules import base, relatedalerts, watchlist, kql, ti, ueba, oof, scoring
+from modules import base, relatedalerts, watchlist, kql, ti, ueba, oof, scoring, aadrisks, mdca, mde
 from classes import Response
 import json
 
@@ -174,6 +174,39 @@ def test_oof():
     oof_response:Response = oof.execute_oof_module(oof_input)
 
     assert oof_response.statuscode == 200
+
+def test_aad_risks():
+    aad_input = {
+        'AddIncidentComments': False,
+        'AddIncidentTask': False,
+        'LookbackInDays': 14,
+        'BaseModuleBody': get_base_module_body()
+    }
+    aad_response:Response = aadrisks.execute_aadrisks_module(aad_input)
+
+    assert aad_response.statuscode == 200
+
+def test_mde_module():
+    aad_input = {
+        'AddIncidentComments': False,
+        'AddIncidentTask': False,
+        'LookbackInDays': 14,
+        'BaseModuleBody': get_base_module_body()
+    }
+    mde_response:Response = mde.execute_mde_module(aad_input)
+
+    assert mde_response.statuscode == 200
+
+def test_mdca_module():
+    aad_input = {
+        'AddIncidentComments': False,
+        'AddIncidentTask': False,
+        'ScoreThreshold': 1,
+        'BaseModuleBody': get_base_module_body()
+    }
+    mdca_response:Response = mdca.execute_mdca_module(aad_input)
+
+    assert mdca_response.statuscode == 200
 
 def test_scoring():
     scoring_input = {


### PR DESCRIPTION
I added some test cases for MDCA and AAD and found issues if a user was not found by the API.

* For example a user who never had a risk level gets returned as a 404 error by the AAD Identity protection API
* MDCA API had a similar problem as well as an issue if there was no enriched user id (like in a on prem user where we only have the SID/guid/samaccountname and the base module can't enrich it because it's not synced)
* MDCA also had an issue in the sum of the threat score as some of the users scores were 'None' so I replaced all None with 0