### PR TITLE
Adding STATNotFound Exception

### DIFF
--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -17,6 +17,10 @@ class STATError(Exception):
         self.source_error = source_error
         self.status_code = status_code
 
+class STATNotFound(STATError):
+    '''A handled STAT exception where the API call returned a 404 error'''
+    pass
+
 class BaseModule:
     '''A base module object'''
     

--- a/modules/aadrisks.py
+++ b/modules/aadrisks.py
@@ -1,4 +1,4 @@
-from classes import BaseModule, Response, AADModule, STATError
+from classes import BaseModule, Response, AADModule, STATError, STATNotFound
 from shared import rest, data
 import json
 
@@ -26,11 +26,8 @@ def execute_aadrisks_module (req_body):
             path = f'/v1.0/identityProtection/riskyUsers/{userid}'
             try:
                 user_risk_level = json.loads(rest.rest_call_get(base_object, api='msgraph', path=path).content)['riskLevel']
-            except STATError as e:
-                if e.source_error['status_code'] == 404:
-                    pass
-                else:
-                    raise STATError(e.error, e.source_error, e.status_code)
+            except STATNotFound:
+                pass
             else:
                 current_account['UserRiskLevel'] = user_risk_level
 

--- a/modules/file.py
+++ b/modules/file.py
@@ -1,4 +1,4 @@
-from classes import BaseModule, Response, FileModule, STATError
+from classes import BaseModule, Response, FileModule, STATError, STATNotFound
 from shared import rest, data
 import json
 
@@ -144,13 +144,9 @@ def convert_list_to_string(hash_list:list):
 def call_file_api(base_object, hash):
     path = f'/api/files/{hash}'
     try:
-        file_data = json.loads(rest.rest_call_get(base_object, 'mde', path).content)
-         
-    except STATError as e:
-        if e.source_error['status_code'] == 404:
-            return None
-        else:
-            raise STATError(e.error, e.source_error, e.status_code)
+        file_data = json.loads(rest.rest_call_get(base_object, 'mde', path).content)   
+    except STATNotFound:
+        return None
         
     return file_data
 

--- a/modules/mdca.py
+++ b/modules/mdca.py
@@ -1,4 +1,4 @@
-from classes import BaseModule, Response, MDCAModule, STATError
+from classes import BaseModule, Response, MDCAModule, STATError, STATNotFound
 from shared import rest, data
 import json,os,base64
 
@@ -29,11 +29,8 @@ def execute_mdca_module (req_body):
             path = f'/api/v1/entities/{pkuser64}'
             try:
                 mdcaresults = json.loads(rest.rest_call_get(base_object, api='mdca', path=path).content)
-            except STATError as e:
-                if e.source_error['status_code'] == 404:
-                    pass
-                else:
-                    raise STATError(e.error, e.source_error, e.status_code)
+            except STATNotFound:
+                pass
             else:
                 current_account['ThreatScore'] = 0 if mdcaresults['threatScore'] is None else mdcaresults['threatScore']
                 current_account['ThreatScoreHistory'] = mdcaresults['threatScoreHistory']

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "1.5.4"
+    "FunctionVersion": "1.5.5"
 }

--- a/shared/rest.py
+++ b/shared/rest.py
@@ -100,7 +100,9 @@ def rest_call_post(base_module:BaseModule, api:str, path:str, body, headers:dict
     headers['Authorization'] = 'Bearer ' + token.token
     response = requests.post(url=url, json=body, headers=headers)
 
-    if response.status_code >= 300:
+    if response.status_code == 404:
+        raise STATNotFound(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
+    elif response.status_code >= 300:
         raise STATError(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
     
     return response
@@ -112,7 +114,9 @@ def rest_call_put(base_module:BaseModule, api:str, path:str, body, headers:dict=
     headers['Authorization'] = 'Bearer ' + token.token
     response = requests.put(url=url, json=body, headers=headers)
 
-    if response.status_code >= 300:
+    if response.status_code == 404:
+        raise STATNotFound(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
+    elif response.status_code >= 300:
         raise STATError(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
     
     return response

--- a/shared/rest.py
+++ b/shared/rest.py
@@ -4,7 +4,7 @@ import datetime as dt
 import json
 import os
 import uuid
-from classes import STATError, BaseModule
+from classes import STATError, STATNotFound, BaseModule
 
 stat_token = {}
 graph_endpoint = os.getenv('GRAPH_ENDPOINT')
@@ -86,7 +86,9 @@ def rest_call_get(base_module:BaseModule, api:str, path:str, headers:dict={}):
     headers['Authorization'] = 'Bearer ' + token.token
     response = requests.get(url=url, headers=headers)
 
-    if response.status_code >= 300:
+    if response.status_code == 404:
+        raise STATNotFound(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
+    elif response.status_code >= 300:
         raise STATError(f'The API call to {api} with path {path} failed with status {response.status_code}', source_error={'status_code': int(response.status_code), 'reason': str(response.reason)})
     
     return response


### PR DESCRIPTION
* Fixes #24 

We had a number of places where we were catching a STATError just to see if it was due to a 404 and re-raising it if it wasn't.  The definition of a new STATNotFound exception which is thrown by the rest (get/post/put) functions makes this handling easier.

As STATNotFound is defined as a child of STATError, the old way will still work so if I missed updating one of the cases where we were checking for 404 it will still continue be caught by a STATError handler.

Old Method
```python
            except STATError as e:
                if e.source_error['status_code'] == 404:
                    pass
                else:
                    raise STATError(e.error, e.source_error, e.status_code)
```

New Method
```python
            except STATNotFound:
                pass
```
