### PR TITLE
Update mde.py

### DIFF
--- a/modules/mde.py
+++ b/modules/mde.py
@@ -75,6 +75,7 @@ def execute_mde_module (req_body):
                     '| extend IPs = todynamic(IPAddresses)'
                     '| mv-expand IPs'
                     '| evaluate bag_unpack(IPs)'
+                    '| extend IPAddress = column_ifexists("IPAddress","")'                     
                     f'| where IPAddress == "{ipaddress}"'
                     '| distinct IPAddress, DeviceId'
                     '| top 30 by DeviceId') #Only returns 30 devices

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "1.5.5"
+    "FunctionVersion": "1.5.6"
 }


### PR DESCRIPTION
Add an empty IPAddress column in the rare yet not impossible situation where the DeviceNetworkInto table has nothing for the selected time as described here: https://github.com/briandelmsft/SentinelAutomationModules/issues/428