### PR TITLE
Fail TI module when all TI checks disabled

### DIFF
--- a/modules/ti.py
+++ b/modules/ti.py
@@ -1,4 +1,4 @@
-from classes import BaseModule, Response, TIModule
+from classes import BaseModule, Response, TIModule, STATError
 from shared import rest, data
 
 def execute_ti_module (req_body):
@@ -14,6 +14,9 @@ def execute_ti_module (req_body):
     check_filehashes = req_body.get('CheckFileHashes', True)
     check_ips = req_body.get('CheckIPs', True)
     check_urls = req_body.get('CheckURLs', True)
+
+    if all((not(check_domains), not(check_filehashes), not(check_ips), not(check_urls))):
+        raise STATError('The Threat Intelligence module was excuted, but all TI checks were disabled.')
 
     if check_domains and base_object.Domains:
         query = base_object.get_domain_kql_table() + '''domainEntities

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -1,6 +1,7 @@
 from modules import base, relatedalerts, watchlist, kql, ti, ueba, oof, scoring, aadrisks, mdca, mde, file
-from classes import Response
+from classes import Response, STATError
 import json, os, requests
+import pytest
 
 
 def test_base_module_incident():
@@ -91,6 +92,22 @@ def test_threat_intel_custom_options():
         'IncidentTaskInstructions': '',
         'BaseModuleBody': get_base_module_body(),
     }
+
+    with pytest.raises(STATError):
+        ti_response:Response = ti.execute_ti_module(ti_input)
+
+def test_threat_intel_custom_options2():
+    ti_input = {
+        'AddIncidentComments': False,
+        'AddIncidentTask': False,
+        'CheckDomains': False,
+        'CheckFileHashes': False,
+        'CheckIPs': False,
+        'CheckURLs': True,
+        'IncidentTaskInstructions': '',
+        'BaseModuleBody': get_base_module_body(),
+    }
+
     ti_response:Response = ti.execute_ti_module(ti_input)
 
     assert ti_response.statuscode == 200


### PR DESCRIPTION
The TI module currently will pass if all checks are disabled.  I don't see any reason why all checks would be turned off on purpose since the module will provide no value, so this will cause an exception to be thrown if it's configured that way

This also updates the test cases to check for the exception and adds a new test case that will return but with no TI found.