### PR TITLE
MDE Device Id Enrichment

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -318,8 +318,31 @@ def enrich_hosts(entities):
         host_name = data.coalesce(host.get('properties',{}).get('hostName'), host.get('HostName'))
         domain_name = data.coalesce(host.get('properties',{}).get('dnsDomain'), host.get('DnsDomain'), '')
         mde_device_id = data.coalesce(host.get('properties',{}).get('additionalData', {}).get('MdatpDeviceId'), host.get('MdatpDeviceId'))
+        fqdn = host_name + '.' + domain_name
+        
+        if not(mde_device_id):
+            query = f'''DeviceInfo
+| where Timestamp > ago(14d)
+| where DeviceName =~ '{fqdn}' or DeviceName has '{host_name}'
+| extend MatchType = iff(DeviceName =~ '{fqdn}', 'FQDN', 'Hostname')
+| summarize arg_max(Timestamp, *) by DeviceId
+| project Timestamp, DeviceId, DeviceName, MatchType, AadDeviceId
+| summarize DeviceIdCount=dcount(DeviceId), DeviceId=max(DeviceId) by MatchType, bin(Timestamp, 12h)
+| sort by Timestamp desc'''
+            results = rest.execute_m365d_query(base_object, query)
+
+            if results:
+                fqdn_matches = list(filter(lambda x: x['MatchType'] == 'FQDN', results))
+                host_matches = list(filter(lambda x: x['MatchType'] == 'Hostname', results))
+                if fqdn_matches:
+                    if fqdn_matches[0]['DeviceIdCount'] == 1:
+                        mde_device_id = fqdn_matches[0]['DeviceId']
+                elif host_matches:
+                    if host_matches[0]['DeviceIdCount'] == 1:
+                        mde_device_id = host_matches[0]['DeviceId']                 
+
         raw_entity = data.coalesce(host.get('properties'), host)
-        base_object.add_host_entity(fqdn=host_name + '.' + domain_name, hostname=host_name, dnsdomain=domain_name, mdedeviceid=mde_device_id, rawentity=raw_entity)
+        base_object.add_host_entity(fqdn=fqdn, hostname=host_name, dnsdomain=domain_name, mdedeviceid=mde_device_id, rawentity=raw_entity) 
 
 def get_account_comment():
     

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "2.0.7"
+    "FunctionVersion": "2.0.8"
 }


### PR DESCRIPTION
* Fixes https://github.com/briandelmsft/SentinelAutomationModules/issues/452

In the event a host entity is received without an MDE device ID, no effort was made to obtain one, so modules like MDE would not function on those host entities.  

This change will do a best effort to lookup the device by FQDN and Hostname to return the MDE device id.  FQDN matches are preferred over Hostname matches.  In the event there is more than one device id found reporting in the last 12 hours with the same type of match (on FQDN or on hostname), we will not enrich since we don't know which device id to use.  If any failure occurs running the query to get the MDE device id the base module will continue without the enrichment