### PR TITLE
Add STAT version to exception messages

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -3,7 +3,7 @@ import traceback as tb
 import json
 import azure.functions as func
 from classes import STATError
-from shared import coordinator
+from shared import coordinator, data
 
 def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     logging.debug('STAT Function started processing a request.')
@@ -20,13 +20,13 @@ def main(req: func.HttpRequest, context: func.Context) -> func.HttpResponse:
     except STATError as e:
         trace = tb.format_exception(None, e, e.__traceback__)
         logging.error(msg={'Error': e.error, 'SourceError': e.source_error, 'InvocationId': context.invocation_id}, exc_info=True)
-        return func.HttpResponse(json.dumps({'Error': e.error, 'InvocationId': context.invocation_id, 'SourceError': e.source_error, 'Traceback': trace}), status_code=e.status_code, mimetype='application/json')
+        return func.HttpResponse(json.dumps({'Error': e.error, 'InvocationId': context.invocation_id, 'SourceError': e.source_error, 'STATVersion': data.get_current_version(), 'Traceback': trace}), status_code=e.status_code, mimetype='application/json')
     except Exception as e:
         trace = tb.format_exception(None, e, e.__traceback__)
         logging.error(e, exc_info=True)
-        return func.HttpResponse(json.dumps({'Error': 'Module processing failed, an unknown exception has occurred.', 'InvocationId': context.invocation_id, 'Traceback': trace}), status_code=400, mimetype='application/json')
+        return func.HttpResponse(json.dumps({'Error': 'Module processing failed, an unknown exception has occurred.', 'InvocationId': context.invocation_id, 'STATVersion': data.get_current_version(), 'Traceback': trace}), status_code=400, mimetype='application/json')
     except:
         logging.error(msg={'Error': 'Module processing failed, an unknown exception has occurred.', 'InvocationId': context.invocation_id}, exc_info=True)
-        return func.HttpResponse(json.dumps({'Error': 'Module processing failed, an unknown exception has occurred.', 'InvocationId': context.invocation_id}), status_code=400, mimetype='application/json')
+        return func.HttpResponse(json.dumps({'Error': 'Module processing failed, an unknown exception has occurred.', 'InvocationId': context.invocation_id, 'STATVersion': data.get_current_version()}), status_code=400, mimetype='application/json')
     
     return func.HttpResponse(body=json.dumps(return_data.body.__dict__), status_code=return_data.statuscode, mimetype=return_data.contenttype)

--- a/modules/base.py
+++ b/modules/base.py
@@ -4,7 +4,6 @@ import json
 import time
 import logging
 import requests
-import pathlib
 
 stat_version = None
 
@@ -381,12 +380,8 @@ def get_ip_comment():
     return data.list_to_html_table(ip_list)
 
 def get_stat_version(version_check_type):
-    global stat_version
 
-    if stat_version is None:
-        with open(pathlib.Path(__file__).parent / 'version.json') as f:
-            stat_version = json.loads(f.read())['FunctionVersion']
-    
+    stat_version = data.get_current_version() 
     available_version = base_object.ModuleVersions.get('STATFunction', '1.4.9')
     logging.info(f'STAT Version check info. Current Version: {stat_version}, Available Version: {available_version}')
     version_check_result = data.version_check(stat_version, available_version, version_check_type)

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "2.0.8"
+    "FunctionVersion": "2.0.9"
 }

--- a/shared/data.py
+++ b/shared/data.py
@@ -1,5 +1,7 @@
 import pandas as pd
 import copy
+import pathlib
+import json
 
 def list_to_html_table(input_list:list, max_rows:int=20, max_cols:int=10, nan_str:str='N/A', escape_html:bool=True, columns:list=None, index:bool=False, justify:str='left'):
     '''Convert a list of dictionaries into an HTML table'''
@@ -79,6 +81,10 @@ def coalesce(*args):
             return arg
         
 def version_check(current_version:str, avaialble_version:str, update_check_type:str):
+    
+    if current_version == 'Unknown':
+        return {'UpdateAvailable': False, 'UpdateType': 'None'}
+    
     current = current_version.split('.')
     available = avaialble_version.split('.')
 
@@ -106,3 +112,13 @@ def return_property_as_list(input_list:list, property_name:str):
 def return_slope(input_list_x:list, input_list_y:list):
     slope = ( ( len(input_list_y) * sum([a * b for a, b in zip(input_list_x, input_list_y)]) ) - ( sum(input_list_x) * sum(input_list_y)) ) / ( ( len(input_list_y) * sum([sq ** 2 for sq in input_list_x])) - (sum(input_list_x) ** 2))
     return slope
+
+def get_current_version():
+
+    try:
+        with open(pathlib.Path(__file__).parent.parent / 'modules/version.json') as f:
+            stat_version = json.loads(f.read())['FunctionVersion']
+    except:
+        stat_version = 'Unknown'
+
+    return stat_version

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -55,6 +55,7 @@ def test_version_check():
     assert data.version_check('1.0.0', '1.0.0', 'Major') == {'UpdateAvailable': False, 'UpdateType': 'None'}
     assert data.version_check('1.0.0', '1.0.0', 'Minor') == {'UpdateAvailable': False, 'UpdateType': 'None'}
     assert data.version_check('1.0.0', '1.0.0', 'Build') == {'UpdateAvailable': False, 'UpdateType': 'None'}
+    assert data.version_check('Unknown', '1.0.0', 'Build') == {'UpdateAvailable': False, 'UpdateType': 'None'}
 
     assert data.version_check('1.0.0', '1.0.1', 'Major') == {'UpdateAvailable': False, 'UpdateType': 'None'}
     assert data.version_check('1.0.0', '1.0.1', 'Minor') == {'UpdateAvailable': False, 'UpdateType': 'None'}
@@ -71,6 +72,9 @@ def test_version_check():
     assert data.version_check('2.0.0', '1.1.1', 'Build') == {'UpdateAvailable': False, 'UpdateType': 'None'}
     assert data.version_check('1.2.0', '1.1.1', 'Build') == {'UpdateAvailable': False, 'UpdateType': 'None'}
     assert data.version_check('1.1.5', '1.1.1', 'Build') == {'UpdateAvailable': False, 'UpdateType': 'None'}
+
+def test_current_version():
+    assert data.get_current_version().startswith('2.')
 
 def test_slope():
     dates_list = [1713376805000, 1713463205000, 1713549605000, 1713636005000, 1713722405000, 1713808805000, 1713895205000, 1713981605000]


### PR DESCRIPTION
- Fixes #87

I've had a few situations come up where I am getting exceptions sent to me to troubleshoot and while the exception is clear, it's unclear which version of STAT it's happening and in a couple cases it's been bugs that were already fixed.  This adds the installed version to the exception information.

I also refactored the code that checks the local version out of the base module and into the data module so it was accessible regardless of which module throws the exception

This includes an update for the test cases to test the new function and ensure it returns a version correctly