### PR TITLE
Base Module BUG with GUIDs and TI Module bug with links

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -156,6 +156,7 @@ def enrich_accounts(entities):
         friendly_name = data.coalesce(account.get('properties',{}).get('friendlyName'), account.get('DisplayName'), account.get('Name'))
         sid = data.coalesce(account.get('properties',{}).get('sid'), account.get('Sid'))
         nt_domain = data.coalesce(account.get('properties',{}).get('ntDomain'), account.get('NTDomain'))
+        object_guid = data.coalesce(account.get('properties',{}).get('objectGuid'), account.get('ObjectGuid'))
         properties = data.coalesce(account.get('properties'), account)
 
         if aad_id:
@@ -166,8 +167,12 @@ def enrich_accounts(entities):
             get_account_by_sid(sid, attributes, properties)
         elif nt_domain and account_name:
             get_account_by_samaccountname(account_name, attributes, properties)
+        elif object_guid:
+            get_account_by_upn_or_id(object_guid, attributes, properties)
         else:
-            if friendly_name.__contains__('@'):
+            if friendly_name is None:
+                base_object.add_account_entity({'RawEntity': properties})
+            elif friendly_name.__contains__('@'):
                 get_account_by_upn_or_id(friendly_name, attributes, properties)
             elif friendly_name.__contains__('S-1-'):
                 get_account_by_sid(friendly_name, attributes, properties)

--- a/modules/ti.py
+++ b/modules/ti.py
@@ -82,6 +82,13 @@ def execute_ti_module (req_body):
     ti_object.AnyTIFound = bool(ti_object.DetailedResults)
     ti_object.TotalTIMatchCount = len(ti_object.DetailedResults)
 
+    if ti_object.DetailedResults:
+        try:
+            ti_object.DetailedResults = data.replace_column_value_in_list(ti_object.DetailedResults, 'Description', '[', '(')
+            ti_object.DetailedResults = data.replace_column_value_in_list(ti_object.DetailedResults, 'Description', ']', ')')
+        except:
+            pass
+
     if req_body.get('AddIncidentComments', True) and base_object.IncidentAvailable:
         
         html_table = data.list_to_html_table(ti_object.DetailedResults)

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "2.0.12"
+    "FunctionVersion": "2.0.14"
 }

--- a/shared/data.py
+++ b/shared/data.py
@@ -12,11 +12,21 @@ def list_to_html_table(input_list:list, max_rows:int=20, max_cols:int=10, nan_st
     return html_table
 
 def update_column_value_in_list(input_list:list, col_name:str, update_str:str):
-    '''Updates the value of a column in each dict in the list, to include the column value in your replacement use [col_value]'''
+    '''Updates the value of a column in each dict in the list with a value from another column, to include the column value in your replacement use [col_value]'''
     updated_list = []
     for row in input_list:
         current_row = copy.copy(row)
         current_row[col_name] = update_str.replace('[col_value]', current_row[col_name])
+        updated_list.append(current_row)
+
+    return updated_list
+
+def replace_column_value_in_list(input_list:list, col_name:str, original_value:str, replacement_value:str):
+    '''Updates the value of a column in each dict in the list, with a static value'''
+    updated_list = []
+    for row in input_list:
+        current_row = copy.copy(row)
+        current_row[col_name] = current_row[col_name].replace(original_value, replacement_value)
         updated_list.append(current_row)
 
     return updated_list

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -36,6 +36,12 @@ def test_update_column_values_in_list():
 
     assert updated_list[0]['Description'] == 'New Value 4 data'
 
+def test_replace_column_values_in_list():
+
+    updated_list = data.replace_column_value_in_list(list_data(), 'Description', '4', '7')
+
+    assert updated_list[0]['Description'] == 'Value 7'
+
 def test_join_lists():
 
     merged_data = data.join_lists(list_data(), list_data2(), 'left', 'Description', 'Description', fill_nan=0)


### PR DESCRIPTION
Fixing bug in base module where account entities with objectGUID only would cause an exception
Fixing bug in TI Module where Defender TI links would not be clickable 