### PR TITLE
MDCA module deprecation

### DIFF
--- a/classes/__init__.py
+++ b/classes/__init__.py
@@ -493,15 +493,6 @@ class MDCAModule:
         self.AnyThreatScoreTrendingUp = False
         self.ModuleName = 'MDCAModule'
 
-    def load_from_input(self, body):
-        self.AboveThresholdCount = body['AboveThresholdCount']
-        self.AnalyzedEntities = body['AnalyzedEntities']
-        self.DetailedResults = body['DetailedResults']
-        self.MaximumScore = body['MaximumScore']
-        self.HighestScorePercentile = body['HighestScorePercentile']
-        self.TopUserThresholdCount = body['TopUserThresholdCount']
-        self.AnyThreatScoreTrendingUp = body['AnyThreatScoreTrendingUp']
-
 class RunPlaybook:
     '''A RunPlaybook module object'''
 

--- a/modules/mdca.py
+++ b/modules/mdca.py
@@ -9,78 +9,11 @@ def execute_mdca_module (req_body):
     base_object = BaseModule()
     base_object.load_from_input(req_body['BaseModuleBody'])
 
-    mdca_endpoint_url = base_object.MultiTenantConfig.get('MDCAUrl',os.getenv('MDCA_ENDPOINT'))
-    if mdca_endpoint_url is None or mdca_endpoint_url == "":
-        raise STATError('There are no configured endpoint for MDCA.')
-
     mdac_object = MDCAModule()
-    ScoreThreshold =  req_body.get('ScoreThreshold', -1)
-    TopUserThreshold =  req_body.get('TopUserThreshold', 10)
-
-    #Check if there is any account before doing the stats
-    if any(account.get('id') is not None for account in base_object.Accounts):
-        path = f'/api/v1/entities/'
-        body=f'{{"limit":{TopUserThreshold},"filters":{{"score":{{"isset":true}}}},"sortField":"score","sortDirection":"desc","performAsyncTotal":true}}'
-        
-        #If the following fails, the module fails
-        mdcastat = json.loads(rest.rest_call_post(base_object, api='mdca', path=path, body=json.loads(body), headers={"Content-Type":"application/json"}).content)
-            
-    for account in base_object.Accounts:
-        userid = account.get('id')
-        if userid:
-            upn = account.get('userPrincipalName')
-            current_account = {
-                'IsTopThreatScore': None,
-                'ThreatScore': 0,
-                'UserId': f'{userid}',
-                'UserPrincipalName': f'{upn}',
-                'ThreatScoreHistory': [],
-                'ThreatScoreTrendingUp':False,
-                'LastThreatScorePercentile':0
-            }
-            pkuser = f'{{"id":"{userid}","inst":0,"saas":11161}}'
-            pkuser64 = base64.b64encode(pkuser.encode('ascii')).decode('ascii')
-            path = f'/api/v1/entities/{pkuser64}'
-            try:
-                mdcaresults = json.loads(rest.rest_call_get(base_object, api='mdca', path=path).content)
-            except STATNotFound:
-                pass
-            else:
-                current_account['IsTopThreatScore'] = any(list.get('id') == userid for list in mdcastat.get('data'))
-                current_account['ThreatScore'] = 0 if mdcaresults['threatScore'] is None else mdcaresults['threatScore']
-                current_account['ThreatScoreHistory'] = mdcaresults['threatScoreHistory']
-                if len(current_account['ThreatScoreHistory']) > 0:
-                    ordered_history = sorted(current_account['ThreatScoreHistory'], key=lambda x: x['dateUtc'])
-                    history_dates = [item['dateUtc'] for item in ordered_history]
-                    history_scores = [item['score'] for item in ordered_history]
-                    current_account['ThreatScoreTrendingUp'] = False if data.return_slope(history_dates,history_scores) <= 0 else True
-                    current_account['LastThreatScorePercentile'] = [item['percentile'] for item in ordered_history][-1]
-            mdac_object.DetailedResults.append(current_account)
-
-    entities_nb = len(mdac_object.DetailedResults)
-    if entities_nb != 0:
-        mdac_object.AnalyzedEntities = entities_nb
-        mdac_object.AboveThresholdCount = sum(1 for score in mdac_object.DetailedResults if score['ThreatScore'] > ScoreThreshold)
-        mdac_object.MaximumScore = max(maximum['ThreatScore'] for maximum in mdac_object.DetailedResults)
-        mdac_object.HighestScorePercentile = max(maximum['LastThreatScorePercentile'] for maximum in mdac_object.DetailedResults)
-        mdac_object.TopUserThresholdCount = sum(1 for top in mdac_object.DetailedResults if top['IsTopThreatScore'] == True)
-        mdac_object.AnyThreatScoreTrendingUp = any(trend.get('ThreatScoreTrendingUp') == True for trend in mdac_object.DetailedResults)
 
     if req_body.get('AddIncidentComments', True):
-        link_template = f'<a href="https://security.microsoft.com/user?aad=[col_value]&tid={base_object.TenantId}" target="_blank">[col_value]</a>'
-        linked_table = data.update_column_value_in_list([{k: v for k, v in DetailedResults.items() if k != 'ThreatScoreHistory'} for DetailedResults in mdac_object.DetailedResults], 'UserId', link_template)
-        html_table = data.list_to_html_table(linked_table, escape_html=False)
-        comment = '<h3>Microsoft Defender for Cloud Apps Module</h3>'
-        comment += f'A total of {mdac_object.AnalyzedEntities} entities were analyzed.<br />'
-        comment += f'<ul><li>Maximum investigation score: {mdac_object.MaximumScore}</li>'
-        comment += f'<li>Highest percentile: {mdac_object.HighestScorePercentile}</li>'
-        comment += f'<li>Users above the score threshold of {ScoreThreshold}: {mdac_object.AboveThresholdCount} </li>'
-        comment += f'<li>Any users trending up: {mdac_object.AnyThreatScoreTrendingUp} </li>'
-        comment += '</ul><br />'
-        comment += f'{html_table}'
+        comment = "The Sentinel Triage AssistanT (STAT) Microsoft Defender for Cloud Apps module has been deprecated.  This is due to Microsoft's depreation of the MDCA investigation score.<br />"
+        comment += "Please remove the MDCA module from your STAT Analysis."
         comment_result = rest.add_incident_comment(base_object, comment)
-
-    if req_body.get('AddIncidentTask', True) and mdac_object.AboveThresholdCount > 0 :
-        task_result = rest.add_incident_task(base_object, req_body.get(f'QueryDescription', 'Review users with an investigation score higher than {ScoreThreshold}'), req_body.get('IncidentTaskInstructions'))
 
     return Response(mdac_object)

--- a/modules/scoring.py
+++ b/modules/scoring.py
@@ -201,24 +201,8 @@ def score_file(score:ScoringModule, module_body, multiplier, label):
         score.append_score(0, f'{label} - No File threats found')
 
 def score_mdca(score:ScoringModule, module_body, per_item, multiplier, label):
-    mdca = MDCAModule()
-    mdca.load_from_input(module_body)
+    score.append_score(0, 'WARNING: MDCA Module was included in scoring, however this module has been deprecated.')
     
-    if per_item:
-        score.append_score((mdca.AboveThresholdCount * 10 * multiplier), label)
-        if mdca.TopUserThresholdCount > 0:
-            score.append_score((mdca.TopUserThresholdCount * 10 * multiplier), f"MDCA - {mdca.TopUserThresholdCount} user(s) in top MDCA risk scores")
-        if mdca.AnyThreatScoreTrendingUp:
-            score.append_score((5 * multiplier), f"MDCA - User risk scores are trending up")
-    elif mdca.AboveThresholdCount > 0:
-        score.append_score((10 * multiplier), label)
-        if mdca.TopUserThresholdCount > 0:
-            score.append_score((10 * multiplier), f"MDCA - {mdca.TopUserThresholdCount} user(s) in top MDCA risk scores")
-        if mdca.AnyThreatScoreTrendingUp:
-            score.append_score((5 * multiplier), f"MDCA - User risk scores are trending up")
-    else:
-        score.append_score(0, label)
-
 def score_mde(score:ScoringModule, module_body, per_item, multiplier, label):
     mde = MDEModule()
     mde.load_from_input(module_body)

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "2.0.16"
+    "FunctionVersion": "2.0.17"
 }

--- a/tests/test_stat.py
+++ b/tests/test_stat.py
@@ -274,18 +274,6 @@ def test_mdca_module():
 
     assert mdca_response.statuscode == 200
 
-def test_mdca_module_custom_options():
-    mdca_input = {
-        'AddIncidentComments': False,
-        'AddIncidentTask': False,
-        'ScoreThreshold': 1,
-        'TopUserThreshold': 5,
-        'BaseModuleBody': get_base_module_body()
-    }
-    mdca_response:Response = mdca.execute_mdca_module(mdca_input)
-
-    assert mdca_response.statuscode == 200
-
 def test_file_module():
     file_input = {
         'AddIncidentComments': False,


### PR DESCRIPTION
This relates to #106 as a result of Microsoft's deprecation of the MDCA investigation priority score announced in Message center MC889532.

- Removes the bulk of the MDCA module to only retail a small schema
- Modifies the scoring module to warn about the deprecation
- Removes an unnecessary test case