### PR TITLE
Adding lookback period to incident comments

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -49,5 +49,5 @@ jobs:
         M365_ENDPOINT: api.security.microsoft.com
         MDE_ENDPOINT: api.securitycenter.microsoft.com
         MDCA_ENDPOINT: ${{ secrets.MDCA_ENDPOINT }}
-        DATE_FORMAT: ${{ env.DATE_FORMAT }}
-        TIME_ZONE: ${{ env.TIME_ZONE }}
+        DATE_FORMAT: ${{ secrets.DATE_FORMAT }}
+        TIME_ZONE: ${{ secrets.TIME_ZONE }}

--- a/modules/exchange.py
+++ b/modules/exchange.py
@@ -62,7 +62,7 @@ def execute_exchange_module (req_body):
         if exch.AuditEvents:
             audit_table = data.list_to_html_table(exch.AuditEvents, max_rows=50, max_cols=15, drop_empty_cols=True)
 
-            a_comment = '<h3>Exchange Online Module - Audit Events</h3>'
+            a_comment = f'<h3>Exchange Online Module - Audit Events (Last {module_lookback} days)</h3>'
             a_comment += f'A total of {len(exch.AuditEvents)} forwarding, delegation and rule audits have been found.<br />'
             a_comment += audit_table
             a_comment_result = rest.add_incident_comment(base_object, a_comment)

--- a/modules/file.py
+++ b/modules/file.py
@@ -127,7 +127,7 @@ union
         
         html_table = data.list_to_html_table(file_object.DetailedResults)
 
-        comment = f'''<h3>File Module</h3>A total of {file_object.AnalyzedEntities} entities were analyzed.<br>{html_table}'''
+        comment = f'''<h3>File Module</h3>A total of {file_object.AnalyzedEntities} entities were analyzed with data from the last 30 days.<br>{html_table}'''
         comment_result = rest.add_incident_comment(base_object, comment)
 
     if req_body.get('AddIncidentTask', False) and file_object.AnalyzedEntities > 0 and base_object.IncidentAvailable:

--- a/modules/mde.py
+++ b/modules/mde.py
@@ -108,7 +108,7 @@ def execute_mde_module (req_body):
         mde_object.AnalyzedEntities = entities_nb
 
     if req_body.get('AddIncidentComments', True):
-        comment = f'<h3>Microsoft Defender for Endpoint Module</h3>'
+        comment = f'<h3>Microsoft Defender for Endpoint Module (Last {lookback} days)</h3>'
         comment += f'A total of {mde_object.AnalyzedEntities} entities were analyzed (Accounts: {nb_accounts} - Hosts: {nb_hosts} - IPs: {nb_ips}).<br />'
 
         if nb_accounts > 0:

--- a/modules/relatedalerts.py
+++ b/modules/relatedalerts.py
@@ -107,7 +107,8 @@ SecurityAlert
 
         #html_table = data.list_to_html_table(results)
         
-        comment = f'''A total of {related_alerts.RelatedAlertsCount} related alerts were found.<br>{html_table}'''
+        comment = f'<h3>Related Alerts Module (Last {lookback} days)</h3>'
+        comment += f'''A total of {related_alerts.RelatedAlertsCount} related alerts were found.<br>{html_table}'''
         comment_result = rest.add_incident_comment(base_object, comment)
 
     if req_body.get('AddIncidentTask', False) and related_alerts.RelatedAlertsFound and base_object.IncidentAvailable:

--- a/modules/ueba.py
+++ b/modules/ueba.py
@@ -67,8 +67,9 @@ userDetails
     if req_body.get('AddIncidentComments', True) and base_object.IncidentAvailable:
         
         html_table = data.list_to_html_table(results)
-
-        comment = f'A total of {ueba_object.AllEntityEventCount} matching UEBA events, {ueba_object.ThreatIntelMatchCount} \
+        
+        comment = f'<h3>User Entity Behavior Analytics Module (Last {lookback} days)</h3>'
+        comment += f'A total of {ueba_object.AllEntityEventCount} matching UEBA events, {ueba_object.ThreatIntelMatchCount} \
             UEBA Threat Intellgience matches and {ueba_object.AnomalyCount} anomalies were found.<br>{html_table}'
         
         comment_result = rest.add_incident_comment(base_object, comment)

--- a/modules/version.json
+++ b/modules/version.json
@@ -1,3 +1,3 @@
 {
-    "FunctionVersion": "2.0.26"
+    "FunctionVersion": "2.0.27"
 }


### PR DESCRIPTION
Where relevant, add lookback period into incident comments so analysts know how far back they are seeing events for.

- Fixes #117 
- Fixes #118 
- Fixes #119 
- Fixes #120 
- Fixes #121 
- Fixes #136 

Also fixes workflow issues with now env variables